### PR TITLE
fix: 구글 인증 방식 변경

### DIFF
--- a/omg-springboot-app/.gitignore
+++ b/omg-springboot-app/.gitignore
@@ -37,3 +37,6 @@ out/
 .vscode/
 
 *.idea
+
+### Custom ###
+credentials.json

--- a/omg-springboot-app/src/main/resources/application-prod.yml
+++ b/omg-springboot-app/src/main/resources/application-prod.yml
@@ -4,14 +4,14 @@ spring:
       max-file-size: 20MB
       max-request-size: 20MB
       enabled: true
+
 gcs:
   bucket-name: own_my_geul_bucket
-  key-file: credentials.json
-
+  credentials:
+    location: classpath:credentials.json
 
 custom:
   ai-server-url: ${AI_SERVER_URL}
-
 
 springdoc:
   swagger-ui:

--- a/omg-springboot-app/src/main/resources/application.yml
+++ b/omg-springboot-app/src/main/resources/application.yml
@@ -4,14 +4,14 @@ spring:
       max-file-size: 20MB
       max-request-size: 20MB
       enabled: true
+
 gcs:
   bucket-name: own_my_geul_bucket
-  key-file: /Users/maeng/desktop/gcp/ownmygeul-4719db2125f4.json
-
+  credentials:
+    location: classpath:credentials.json
 
 custom:
   ai-server-url: ${AI_SERVER_URL}
-
 
 springdoc:
   swagger-ui:


### PR DESCRIPTION
## Overview
- 구글 인증 방식 변경

## Change Log
- 기존 방식: application.yml의 절대 경로로 인증
- 변경 방식: credentials.json파일을 resources에 두고 classpath 를 사용하여 인증
- 이유: cloud run, github secrets 등 에서 json 파일을 환경 변수로 설정해주는 기능을 제공하지 않고, CI/CD 구축 시에도 바틀넥이 생길 것으로 예상

## To Reviewer
- 바틀넥이 생기는 부분을 제거하였습니다.

## Issue Tags